### PR TITLE
Add drivebase module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,166 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bytemuck"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+
+[[package]]
+name = "ctre"
+version = "0.8.0"
+source = "git+https://github.com/first-rust-competition/ctre-rs#eb1fd8bcfd8745c391e7dfbb96757dc5e9d522dc"
+dependencies = [
+ "bitflags",
+ "ctre-data",
+ "ctre-sys",
+ "memoffset",
+ "num-traits",
+]
+
+[[package]]
+name = "ctre-data"
+version = "0.5.15"
+source = "git+https://github.com/first-rust-competition/ctre-rs#eb1fd8bcfd8745c391e7dfbb96757dc5e9d522dc"
+dependencies = [
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "smart-default",
+]
+
+[[package]]
+name = "ctre-sys"
+version = "5.15.0"
+source = "git+https://github.com/first-rust-competition/ctre-rs#eb1fd8bcfd8745c391e7dfbb96757dc5e9d522dc"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2 1.0.46",
+]
+
+[[package]]
+name = "smart-default"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+dependencies = [
+ "proc-macro2 1.0.46",
+ "quote 1.0.21",
+ "syn 1.0.102",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+dependencies = [
+ "proc-macro2 1.0.46",
+ "quote 1.0.21",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "wpilib"
@@ -28,6 +184,7 @@ checksum = "aac28154c5b91968d15d183a9fb512e5ad41837e0c838700e673285e0c59fdf0"
 name = "wpilibrust"
 version = "0.1.0"
 dependencies = [
+ "ctre",
  "wpilib",
  "wpilib-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 wpilib = "0.4.0"
 wpilib-sys = "0.4.0"
+ctre = { git = "https://github.com/first-rust-competition/ctre-rs" }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,6 @@
+pub mod can {
+    pub const DRIVE_LEFT1: u8 = 1;
+    pub const DRIVE_LEFT2: u8 = 2;
+    pub const DRIVE_RIGHT1: u8 = 3;
+    pub const DRIVE_RIGHT2: u8 = 4;
+}

--- a/src/drivebase.rs
+++ b/src/drivebase.rs
@@ -1,0 +1,90 @@
+#![allow(dead_code)]
+extern crate ctre;
+use ctre::mot::{VictorSPX, MotorController, ControlMode, Demand};
+
+use crate::constants::can;
+
+#[derive(Debug)]
+pub struct Drivebase {
+    left1: VictorSPX,
+    left2: VictorSPX,
+    right1: VictorSPX,
+    right2: VictorSPX,
+    left_power: f64,
+    right_power: f64,
+}
+
+impl Drivebase {
+    pub fn new() -> Self {
+        Self {
+            left1: VictorSPX::new(can::DRIVE_LEFT1),
+            left2: VictorSPX::new(can::DRIVE_LEFT2),
+            right1: VictorSPX::new(can::DRIVE_RIGHT1),
+            right2: VictorSPX::new(can::DRIVE_RIGHT2),
+            left_power: 0_f64,
+            right_power: 0_f64,
+        }
+    }
+
+    /// Drives the robot by speed and rotation.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `x` - forward/reverse speed of the robot, between -1 and 1. Forwards is positive.
+    /// * `y` - left/right rotation of the robot, between -1 and 1. Right is positive.
+    /// * `square_inputs` - makes the input less sensitive at lower speeds. Recommended if passing in analog stick values.
+    pub fn arcade_drive(&mut self, x: f64, y: f64, square_inputs: bool) {
+        let mut x = x.clamp(-1.0, 1.0);
+        let mut y = y.clamp(-1.0, 1.0);
+
+        if square_inputs {
+            x = x.powi(2).copysign(x);
+            y = y.powi(2).copysign(y);
+        }
+
+        let max_input = x.abs().max(y.abs()).copysign(x);
+
+        let (mut left_speed, mut right_speed) = match (x.is_sign_positive(), y.is_sign_positive()) {
+            (true, true) | (false, false) => (max_input, x - y),
+            (true, false) | (false, true) => (x + y, max_input),
+        };
+
+        let max_magnitude = left_speed.abs().max(right_speed.abs());
+        if max_magnitude > 1.0 {
+            left_speed /= max_magnitude;
+            right_speed /= max_magnitude;
+        }
+
+        self.left_power = left_speed;
+        self.right_power = right_speed;
+    }
+
+    /// Drives the robot by left- and right-side speeds.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `left` - left-side speed of the robot, between -1 and 1. Forwards is positive.
+    /// * `right` - right-side speed of the robot, between -1 and 1. Forwards is positive.
+    /// * `square_inputs` - makes the input less sensitive at lower speeds.
+    pub fn tank_drive(&mut self, left: f64, right: f64, square_inputs: bool) {
+        let mut left = left.clamp(-1.0, 1.0);
+        let mut right = right.clamp(-1.0, 1.0);
+
+        if square_inputs {
+            left = left.powi(2).copysign(left);
+            right = right.powi(2).copysign(right);
+        }
+
+        self.left_power = left;
+        self.right_power = right;
+    }
+
+    /// Sends the latest speed values to the motor controllers.
+    /// Must be called periodically to avoid tripping watchdogs.
+    pub fn feed_motors(&mut self) {
+        self.left1.set(ControlMode::PercentOutput, self.left_power, Demand::Neutral);
+        self.left2.set(ControlMode::PercentOutput, self.left_power, Demand::Neutral);
+        self.right1.set(ControlMode::PercentOutput, self.right_power, Demand::Neutral);
+        self.right2.set(ControlMode::PercentOutput, self.right_power, Demand::Neutral);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,23 @@
 extern crate wpilib;
 
 mod wpilibfill;
-use wpilibfill::*;
+mod constants;
+mod drivebase;
 
+use wpilibfill::*;
 use wpilib::ds::DriverStation;
+use drivebase::Drivebase;
 
 #[derive(Debug)]
-struct Robot {}
+struct Robot {
+    drivebase: Drivebase,
+}
 
 impl robot::IterativeRobot for Robot {
     fn new(_ds: &DriverStation) -> Robot {
-        Robot {}
+        Robot {
+            drivebase: Drivebase::new(),
+        }
     }
 
     fn disabled_init(&mut self) {
@@ -37,7 +44,9 @@ impl robot::IterativeRobot for Robot {
 
     fn test_periodic(&mut self) {}
 
-    fn robot_periodic(&mut self) {}
+    fn robot_periodic(&mut self) {
+        self.drivebase.feed_motors();
+    }
 }
 
 fn main() {


### PR DESCRIPTION
Adds a module for drivebase control, mimicking part of WPILib's DifferentialDrive API.

Draft because I haven't been able to build it (ctre-sys is missing a static library that I haven't been able to find yet).